### PR TITLE
Фикс проглатывания сообщений в пм-ках

### DIFF
--- a/code/modules/admin/verbs/adminhelp.dm
+++ b/code/modules/admin/verbs/adminhelp.dm
@@ -58,7 +58,7 @@ var/list/adminhelp_ignored_words = list("unknown","the","a","an","of","monkey","
 								msg += " <A HREF='?_src_=holder;adminchecklaws=\ref[mob]'>(CL)</A>"
 							msg += "</b> "
 							continue
-			msg += "[original_word] "
+		msg += "[original_word] "
 
 	return msg
 

--- a/code/modules/cciaa/cciaa.dm
+++ b/code/modules/cciaa/cciaa.dm
@@ -89,7 +89,10 @@
 	else
 		data += "<center>No faxes have been sent out.</center>"
 
-	usr << browse("<HTML><HEAD><TITLE>Centcomm Fax History</TITLE></HEAD><BODY>[data]</BODY></HTML>", "window=Centcomm Fax History")
+	usr << browse(
+		"<HTML><HEAD><meta charset='utf-8'><TITLE>Centcomm Fax History</TITLE></HEAD><BODY>[data]</BODY></HTML>",
+		"window=Centcomm Fax History"
+	)
 
 
 /client/proc/launch_ccia_shuttle()

--- a/code/modules/paperwork/paper_bundle.dm
+++ b/code/modules/paperwork/paper_bundle.dm
@@ -135,7 +135,15 @@
 	else if(istype(pages[page], /obj/item/photo))
 		var/obj/item/photo/P = W
 		send_rsc(user, P.img, "tmp_photo.png")
-		user << browse(dat + "<html><head><title>[P.name]</title></head>" + "<body style='overflow:hidden'>" + "<div> <img src='tmp_photo.png' width = '180'" + "[P.scribble ? "<div> Written on the back:<br><i>[P.scribble]</i>" : null]" + "</body></html>", "window=[name]")
+		user << browse(
+			dat \
+			+ "<html><head><meta charset='utf-8'><title>[P.name]</title></head>" \
+			+ "<body style='overflow:hidden'>" \
+			+ "<div> <img src='tmp_photo.png' width = '180'" \
+			+ "[P.scribble ? "<div> Written on the back:<br><i>[P.scribble]</i>" : null]" \
+			+ "</body></html>",
+			"window=[name]"
+		)
 
 /obj/item/paper_bundle/attack_self(mob/user as mob)
 	src.show_content(user)

--- a/code/modules/paperwork/photography.dm
+++ b/code/modules/paperwork/photography.dm
@@ -69,7 +69,13 @@ var/global/photo_count = 0
 
 /obj/item/photo/proc/show(mob/user as mob)
 	send_rsc(user, img, "tmp_photo_[id].png")
-	user << browse("<html><head><title>[name]</title></head>" + "<body style='overflow:hidden;margin:0;text-align:center'>" + "<img src='tmp_photo_[id].png' width='[64*photo_size]' style='-ms-interpolation-mode:nearest-neighbor' />" + "[scribble ? "<br>Written on the back:<br><i>[scribble]</i>" : ""]" + "</body></html>", "window=book;size=[64*photo_size]x[scribble ? 400 : 64*photo_size]")
+	user << browse(
+		"<html><head><meta charset='utf-8'><title>[name]</title></head>" \
+		+ "<body style='overflow:hidden;margin:0;text-align:center'>" \
+		+ "<img src='tmp_photo_[id].png' width='[64*photo_size]' style='-ms-interpolation-mode:nearest-neighbor' />" \
+		+ "[scribble ? "<br>Written on the back:<br><i>[scribble]</i>" : ""]" \
+		+ "</body></html>", "window=book;size=[64*photo_size]x[scribble ? 400 : 64*photo_size]"
+	)
 	onclose(user, "[name]")
 	return
 


### PR DESCRIPTION
# Фикс проглатывания сообщений в пм-ках

ПМ-ки теперь должны приходить полные, без "проглоченных" букв. При этом у админов осталась возможность изучать "ключевые" для них слова.

![изображение](https://github.com/RU-Aurora-space-station13/RU-Aurora/assets/22749671/c51e4fd2-0764-48f0-8c9f-bb24cea90ecd)

## Изменения

- Исправлено: Сообщения в пм-ках прилетают полные
- Исправлено: Кириллические надписи на фотография отображаются корректно
- Исправлено: Кириллические надписи в окне `Check fax history` отображаются корректно
- Исправлено: В стопках листов кириллические символы подписей фотографий отображаются корректно
