### PR TITLE
Cyrillic in drunken speech

### DIFF
--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -382,18 +382,28 @@ var/list/global/organ_rel_size = list(
 
 /proc/slur(phrase, strength = 100)
 	phrase = html_decode(phrase)
-	var/leng=length(phrase)
-	var/counter=length(phrase)
+	var/leng=length_char(phrase)
+	var/counter=length_char(phrase)
 	var/newphrase=""
 	var/newletter=""
 	while(counter>=1)
-		newletter=copytext(phrase,(leng-counter)+1,(leng-counter)+2)
+		newletter=copytext_char(phrase,(leng-counter)+1,(leng-counter)+2)
 		if(prob(strength))
 			if(rand(1,3)==3)
 				if(lowertext(newletter)=="o")	newletter="u"
 				if(lowertext(newletter)=="s")	newletter="ch"
 				if(lowertext(newletter)=="a")	newletter="ah"
 				if(lowertext(newletter)=="c")	newletter="k"
+
+				// Russian specifics
+				switch (lowertext(newletter))
+					if ("a")
+						newletter = "ах"
+					if ("ч")
+						newletter = "ш"
+					if ("з")
+						newletter = "с"
+
 			switch(rand(1,15))
 				if(1,3,5,8)
 					newletter="[lowertext(newletter)]"


### PR DESCRIPTION
# Кириллица в "пьяной" речи

Заменяет в проке `slur` все некоторые проки на аналоги с постфиксом `_char`, чтобы обрабатывался юникод и текст на кириллице нормально отображался у пьяных кукол.

Также добавил небольшой хендл букв на кириллице, чтобы они заменялись на "пьяные" аналоги
