### PR TITLE
Fixes for some interface windows

### DIFF
--- a/code/__DEFINES/_macros.dm
+++ b/code/__DEFINES/_macros.dm
@@ -128,7 +128,7 @@
 #define to_world(message)                                   to_chat(world, message)
 #define sound_to(target, sound)                             to_target(target, sound)
 #define to_save(handle, value)                              to_target(handle, value) //semantics postport: what did they mean by this
-#define show_browser(target, content, title) to_target(target, browse(findtext_char(content, "<html><head>")?replacetext_char(content, "<html><head>", "<html><head><meta charset='utf-8'>"):findtext_char(content, "<head>")?replacetext_char(content, "<head>", "<head><meta charset='utd-8'>"):"<head><meta charset='utf-8'>[content]", title))
+#define show_browser(target, content, title)                to_target(target, browse(findtext_char(content, "<html><head>")?replacetext_char(content, "<html><head>", "<html><head><meta charset='utf-8'>"):findtext_char(content, "<head>")?replacetext_char(content, "<head>", "<head><meta charset='utd-8'>"):"<head><meta charset='utf-8'>[content]", title))
 #define send_rsc(target, content, title)                    to_target(target, browse_rsc(content, title))
 #define send_output(target, msg, control)                   to_target(target, output(msg, control))
 #define send_link(target, url)                              to_target(target, link(url))

--- a/code/game/machinery/newscaster.dm
+++ b/code/game/machinery/newscaster.dm
@@ -988,7 +988,7 @@ var/list/obj/machinery/newscaster/allCasters = list()
 
 		dat+="<BR><HR><div align='center'>[src.curr_page+1]</div>"
 
-		human_user << browse(dat, "window=newspaper_main;size=300x400")
+		show_browser(human_user, dat, "window=newspaper_main;size=300x400")
 		onclose(human_user, "newspaper_main")
 	else
 		to_chat(user, "The paper is full of intelligible symbols!")

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -339,7 +339,7 @@ var/global/enabled_spooking = 0
 		dat += "<A href='?src=\ref[src];add_player_info=[key]'>Add Comment</A><br>"
 
 		dat += "</body></html>"
-		usr << browse(dat, "window=adminplayerinfo;size=480x480")
+		show_browser(usr, dat, "window=adminplayerinfo;size=480x480")
 	else
 		show_notes_sql(key)
 
@@ -599,7 +599,7 @@ var/global/enabled_spooking = 0
 			dat+="Please report this on GitHub, along with what you did to make this appear."
 
 
-	usr << browse(dat, "window=admincaster_main;size=400x600")
+	show_browser(usr, dat, "window=admincaster_main;size=400x600")
 	onclose(usr, "admincaster_main")
 
 

--- a/code/modules/admin/player_notes_sql.dm
+++ b/code/modules/admin/player_notes_sql.dm
@@ -176,7 +176,7 @@
 			dat += "<tr><td colspan='4' bgcolor='white'>&nbsp</td></tr>"
 
 	dat += "</table>"
-	usr << browse(dat,"window=lookupnotes;size=900x500")
+	show_browser(usr, dat, "window=lookupnotes;size=900x500")
 
 /proc/show_player_info_discord(var/ckey)
 	if (!ckey)

--- a/code/modules/admin/verbs/warning.dm
+++ b/code/modules/admin/verbs/warning.dm
@@ -408,7 +408,7 @@
 
 		dat +="</table>"
 
-	usr << browse(dat, "window=lookupwarns;size=900x500")
+	show_browser(usr, dat, "window=lookupwarns;size=900x500")
 	feedback_add_details("admin_verb","WARN-LKUP")
 
 //Admin Proc to add a new User Notification

--- a/code/modules/paperwork/folders.dm
+++ b/code/modules/paperwork/folders.dm
@@ -61,7 +61,7 @@
 		dat += "<A href='?src=\ref[src];remove=\ref[Pb]'>Remove</A> <A href='?src=\ref[src];rename=\ref[Pb]'>Rename</A> - <A href='?src=\ref[src];browse=\ref[Pb]'>[Pb.name]</A><BR>"
 	for(var/obj/item/sample/Pf in src)
 		dat += "<A href='?src=\ref[src];remove=\ref[Pf]'>Remove</A> - [Pf.name]<BR>"
-	user << browse(dat, "window=folder")
+	show_browser(user, dat, "window=folder")
 	onclose(user, "folder")
 	add_fingerprint(usr)
 	return


### PR DESCRIPTION
# Исправления в некоторых окнах интерфейса

Небольшие изменения для корректного отображения кириллицы.

Изменено:

- Газеты
- Команда `Show Player Info`
- Команда `Access Newscaster Network`
- Прок `show_notes_sql` (Требуется проверка!)
- Панель предупреждений (`warning_panel`)
- Папки
- Отступы перед телом макроса `show_browser`
