### PR TITLE
Fix cyrillic letters rendering in whisper and species window

### DIFF
--- a/code/modules/client/preference_setup/general/03_body.dm
+++ b/code/modules/client/preference_setup/general/03_body.dm
@@ -903,8 +903,7 @@ var/global/list/valid_bloodtypes = list("A+", "A-", "B+", "B-", "AB+", "AB-", "O
 		dat += "\[<a href='?src=\ref[src];set_species=[html_encode(pref.species_preview)]'>select</a>\]"
 	dat += "</center>"
 
-
-	user << browse(dat.Join(), "window=species;size=700x400")
+	show_browser(user, dat.Join(), "window=species;size=700x400")
 
 /*/datum/category_item/player_setup_item/general/body/proc/reset_limbs()
 

--- a/code/modules/mob/living/whisper.dm
+++ b/code/modules/mob/living/whisper.dm
@@ -28,11 +28,11 @@
 
 	if(!had_speaking)
 		if(speaking)
-			message = copytext(message,2+length(speaking.key))
+			message = copytext_char(message,2+length(speaking.key))
 		else
 			speaking = get_default_language()
 
-	if(length(message) >= 1 && copytext(message, 1, 2) == "%")
+	if(length(message) >= 1 && copytext_char(message, 1, 2) == "%")
 		if(speaking?.sing_verb)
 			is_singing = TRUE
 

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -368,7 +368,7 @@ var/list/global/organ_rel_size = list(
 	p = 1
 	var/intag = 0
 	while(p <= n)
-		var/char = copytext(te, p, p + 1)
+		var/char = copytext_char(te, p, p + 1)
 		if (char == "<") //let's try to not break tags
 			intag = !intag
 		if (intag || char == " " || prob(pr))


### PR DESCRIPTION
# Изменения

Исправлено отображение кириллицы в следующих случаях:

1. В окне с информацией о выбранном виде/расы персонажа (species)
2. При послушивании шепота в пределах двух тайлов