### PR TITLE
Cyrrilic in faction menu

### DIFF
--- a/code/modules/client/preference_setup/occupation/occupation.dm
+++ b/code/modules/client/preference_setup/occupation/occupation.dm
@@ -461,7 +461,7 @@
 		dat += "<br><span class='warning'>[faction.get_selection_error(pref, user)]</span>"
 	dat += "</center>"
 
-	user << browse(dat.Join(), "window=factionpreview;size=750x450")
+	show_browser(user, dat.Join(), "window=factionpreview;size=750x450")
 
 /datum/category_item/player_setup_item/occupation/proc/validate_and_set_faction(selected_faction)
 	var/datum/faction/faction = SSjobs.name_factions[selected_faction]


### PR DESCRIPTION
# Кириллица в меню выбора фракций

Исправляет отображение кириллицы в окне выбора фракций

![изображение](https://github.com/RU-Aurora-space-station13/RU-Aurora/assets/22749671/9232bf65-4e7e-45e1-823d-800536d846fd)
